### PR TITLE
Add helper for high retention ranges

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -27,6 +27,7 @@ if (!fs.existsSync(clipsDir)) fs.mkdirSync(clipsDir);
 app.use('/clips', express.static(clipsDir));
 
 const youtube = google.youtube({ version: 'v3', auth: process.env.YT_API_KEY });
+const youtubeAnalytics = google.youtubeAnalytics('v2');
 const backgroundSources = {
   minecraft:    'https://www.youtube.com/watch?v=85z7jqGAGcc',
   gta5:         'https://www.youtube.com/watch?v=EUNw8oY3W7g',
@@ -38,6 +39,47 @@ function toHHMMSS(sec) {
         m = Math.floor((sec%3600)/60).toString().padStart(2,'0'),
         s = Math.floor(sec%60).toString().padStart(2,'0');
   return `${h}:${m}:${s}`;
+}
+
+function parseISODuration(dur) {
+  const m = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(dur);
+  return (m && (
+    (m[1] ? +m[1] * 3600 : 0) +
+    (m[2] ? +m[2] * 60 : 0) +
+    (m[3] ? +m[3] : 0)
+  )) || 0;
+}
+
+async function getHighRetentionRanges(videoId, oauth2Client) {
+  const detailResp = await youtube.videos.list({ part: 'contentDetails', id: videoId });
+  if (!detailResp.data.items.length) throw new Error('Video not found');
+  const durationSec = parseISODuration(detailResp.data.items[0].contentDetails.duration);
+
+  const resp = await youtubeAnalytics.reports.query({
+    auth: oauth2Client,
+    ids: 'channel==MINE',
+    startDate: '2020-01-01',
+    endDate: new Date().toISOString().slice(0, 10),
+    metrics: 'relativeRetentionPerformance',
+    dimensions: 'elapsedVideoTimeRatio',
+    filters: `video==${videoId}`,
+    maxResults: 200
+  });
+  const rows = resp.data.rows || [];
+  const ranges = [];
+  for (let i = 0; i < rows.length; i++) {
+    const [ratio, retention] = rows[i];
+    const nextRatio = i < rows.length - 1 ? rows[i + 1][0] : 1;
+    if (retention > 1.0) {
+      ranges.push({
+        start: Math.round(ratio * durationSec),
+        end: Math.round(nextRatio * durationSec),
+        retention
+      });
+    }
+  }
+  ranges.sort((a, b) => b.retention - a.retention);
+  return ranges.map(r => [r.start, r.end]);
 }
 
 async function getLatestVideoId(channelId) {
@@ -253,3 +295,5 @@ app.get('/api/clips', async (req, res) => {
 });
 
 app.listen(process.env.PORT || 5000, () => console.log('Server listening on 5000'));
+
+module.exports.getHighRetentionRanges = getHighRetentionRanges;


### PR DESCRIPTION
## Summary
- query YouTube Analytics for relative retention
- parse above-average segments
- export `getHighRetentionRanges` helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5dddd4c8332bc772e040d4b2b7b