### PR TITLE
Refactor clip extraction to use retention ranges

### DIFF
--- a/backend/analytics.js
+++ b/backend/analytics.js
@@ -1,0 +1,10 @@
+const { google } = require('googleapis');
+
+async function getHighRetentionRanges(videoId, oauth2Client) {
+  // Placeholder implementation. Should call the YouTube Analytics API
+  // and return an array of { startSec, endSec } objects representing
+  // the high audience retention ranges for the given video.
+  return [];
+}
+
+module.exports = { getHighRetentionRanges };


### PR DESCRIPTION
## Summary
- import new `getHighRetentionRanges` helper and OAuth2 client
- stub out `getHighRetentionRanges` helper module
- replace comment-based timestamp logic with viewer retention ranges

## Testing
- `node -c backend/index.js`

------
https://chatgpt.com/codex/tasks/task_e_683fa5f2fb948332a4e4184709e77f9e